### PR TITLE
Nye enum for Kreditortype, OffentligIdType, og Valutakode. Og utvider…

### DIFF
--- a/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/diverse/Språk.kt
+++ b/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/diverse/Språk.kt
@@ -1,9 +1,45 @@
 package no.nav.bidrag.domene.enums.diverse
 
-enum class Språk {
-    NB,
-    NN,
-    DE,
-    FR,
-    EN,
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(enumAsRef = true, name = "Språk")
+enum class Språk(
+    val visningsnavn: String,
+) {
+    NB("Norsk bokmål"),
+    NN("Norsk nynorsk"),
+    AR("Arabisk"),
+    DA("Dansk"),
+    DE("Tysk"),
+    EN("Engelsk"),
+    EL("Gresk"),
+    ET("Estisk"),
+    ES("Spansk"),
+    FI("Finsk"),
+    FR("Franks"),
+    IS("Islandsk"),
+    IT("Italiensk"),
+    JA("Japansk"),
+    HR("Kroatisk"),
+    LV("Latvisk"),
+    LT("Litauisk"),
+    NL("Nederlandsk"),
+    PL("Polsk"),
+    PT("Portugisisk"),
+    RO("Rumensk"),
+    RU("Russisk"),
+    SR("Serbisk"),
+    SL("Slovensk"),
+    SK("Slovakisk"),
+    SV("Svensk"),
+    TH("Thai"),
+    TR("Tyrkisk"),
+    UK("Ukrainsk"),
+    HU("Ungarsk"),
+    VI("Vietnamesisk"),
+    ;
+
+    companion object {
+        fun fraVisningsnavn(visningsnavn: String): Språk? = entries.firstOrNull { it.visningsnavn == visningsnavn }
+    }
 }

--- a/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/Kreditortype.kt
+++ b/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/Kreditortype.kt
@@ -1,0 +1,22 @@
+package no.nav.bidrag.domene.enums.samhandler
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(enumAsRef = true, name = "Kreditortype")
+enum class Kreditortype(
+    val visningsnavn: String,
+) {
+    UTENRIKSSTASJON("Utenriksstasjon"),
+    ADVOKAT("Advokat"),
+    ARBEIDSGIVER("Arbeidsgiver"),
+    REELL_MOTTAKER("Reell mottaker"),
+    UTENLANDSK_PERSONNR("Utenlandsk person"),
+    UTENLANDSK_FOGD("Utenlandsk fogd"),
+    SOSIALKONTOR("Sosialkontor"),
+    BARNEVERNSINSTITUSJON("Barnevernsinstitusjon"),
+    ;
+
+    companion object {
+        fun fraVisningsnavn(visningsnavn: String): Kreditortype? = entries.firstOrNull { it.visningsnavn == visningsnavn }
+    }
+}

--- a/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/OffentligIdType.kt
+++ b/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/OffentligIdType.kt
@@ -1,0 +1,18 @@
+package no.nav.bidrag.domene.enums.samhandler
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(enumAsRef = true, name = "Offentlig ID type")
+enum class OffentligIdType(
+    val visningsnavn: String,
+) {
+    NORSK_ORGNR("Norsk orgnummer"),
+    NORSK_FNR("Norsk personnummer"),
+    UTENLANDSK_ORGNR("Utenlandsk orgnummer"),
+    UTENLANDSK_FNR("Utenlandsk personnummer"),
+    ;
+
+    companion object {
+        fun fraVisningsnavn(visningsnavn: String): OffentligIdType? = entries.firstOrNull { it.visningsnavn == visningsnavn }
+    }
+}

--- a/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/Valutakode.kt
+++ b/bidrag-domene/src/main/kotlin/no/nav/bidrag/domene/enums/samhandler/Valutakode.kt
@@ -1,0 +1,52 @@
+package no.nav.bidrag.domene.enums.samhandler
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(enumAsRef = true, name = "Valutakode")
+enum class Valutakode(
+    val visningsnavn: String,
+) {
+    ALL("Albanske lek"),
+    ANG("NL Antillene Gylden"),
+    AUD("Australske dollar"),
+    BAM("Bosniske Mark"),
+    BGN("Bulgarsk lev"),
+    BRL("Brasilske reais"),
+    CAD("Canadiske dollar"),
+    CHF("Sveitsiske Franc"),
+    CNY("Kinesiske Yen"),
+    CZK("Tsjekkiske koruna"),
+    DKK("Danske kroner"),
+    EEK("Estiske kroon"),
+    EUR("Euro"),
+    GBP("Britiske Pund"),
+    HKD("Hong Kong dollar"),
+    HRK("Kroatiske kuna"),
+    HUF("Ungarske forint"),
+    INR("Indiske Rupees"),
+    ISK("Islandske kroner"),
+    JPY("Japanske Yen"),
+    LTL("Litauiske litas"),
+    LVL("Latviske lat"),
+    MAD("Marokkansk dirham"),
+    NOK("Norske kroner"),
+    NZD("New Zealand dollar"),
+    PKR("Pakistanske rupi"),
+    PLN("Polske zloty"),
+    RON("Rumenske leu"),
+    RSD("Serbiske dinar"),
+    SEK("Svenske kroner"),
+    THB("Thailandske bath"),
+    TND("Tunisiske dinarer"),
+    TRY("Tyrkiske lire"),
+    UAH("Ukrainsk hryvnia"),
+    USD("Amerikanske dollar"),
+    VND("Vietnamesisk dong "),
+    ZAR("Sør-Afrika Rep. rand"),
+    PHP("Filippinske peso"),
+    ;
+
+    companion object {
+        fun fraVisningsnavn(visningsnavn: String): Valutakode? = entries.firstOrNull { it.visningsnavn == visningsnavn }
+    }
+}


### PR DESCRIPTION
… språk med visningsnavn og flere språk